### PR TITLE
Add overload signature for getColorAsync method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,11 @@ export class FastAverageColor {
     /**
      * Get asynchronously the average color from not loaded image.
      */
+    public getColorAsync(resource: FastAverageColorResource, options?: FastAverageColorOptions): Promise<FastAverageColorResult>;
+    /**
+     * Get average color from image url
+     */
+    public getColorAsync(imageUrl: string, options?: FastAverageColorOptions): Promise<FastAverageColorResult>;
     public getColorAsync(resource: string | FastAverageColorResource, options?: FastAverageColorOptions): Promise<FastAverageColorResult> {
         if (!resource) {
             return Promise.reject(getError('call .getColorAsync() without resource.'));


### PR DESCRIPTION
This edit will produce a type declaration with overload signature that is clearer for users to read.

Before

```ts
// index.d.ts
export declare class FastAverageColor {
    /**
     * Get asynchronously the average color from not loaded image.
     */
    getColorAsync(resource: string | FastAverageColorResource, options?: FastAverageColorOptions): Promise<FastAverageColorResult>;
}
```

After

```ts
// index.d.ts
export declare class FastAverageColor {
    /**
     * Get asynchronously the average color from not loaded image.
     */
    getColorAsync(resource: FastAverageColorResource, options?: FastAverageColorOptions): Promise<FastAverageColorResult>;
    /**
     * Get average color from image url
     */
    getColorAsync(imageUrl: string, options?: FastAverageColorOptions): Promise<FastAverageColorResult>;
}
```