### PR TITLE
Set image source prior to calling bindImageEvents  in getColorAsync

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,8 +35,8 @@ export class FastAverageColor {
 
             const img = new Image();
             img.crossOrigin = options && options.crossOrigin || '';
-            const promise = this.bindImageEvents(img, options)
             img.src = resource;
+            const promise = this.bindImageEvents(img, options)
 
             return promise;
         } else if (isInstanceOfHTMLImageElement(resource) && !resource.complete) {


### PR DESCRIPTION
When calling `getColorAsync` using a string source, I observed an error `FastAverageColor: incorrect sizes for resource ""` happening.
This appears to be related to the order of the source not being set prior to calling the bind image event.